### PR TITLE
Fix deprecation warning in Rails 6.1

### DIFF
--- a/lib/active_storage_silent_logs/railtie.rb
+++ b/lib/active_storage_silent_logs/railtie.rb
@@ -3,7 +3,9 @@ module ActiveStorageSilentLogs
     initializer "active_storage_silent_logs" do
       Rails.application.config.middleware.insert_before Rack::Sendfile, ActiveStorageSilentLogs::SilentLogger
 
-      ActiveStorage::BaseController.send :include, ActiveStorageSilentLogs::Controller
+      Rails.application.reloader.to_prepare do
+        ActiveStorage::BaseController.send :include, ActiveStorageSilentLogs::Controller
+      end
 
       Rails.application.config.filter_parameters += [:content_type, :disposition, :encoded_key, :signed_blob_id, :variation_key]
     end


### PR DESCRIPTION
I found the following deprecation warning on boot in rails 6.1
According to this warning, autoloading during initialization seems to cause an error in the next version.
I actually tried updating to rails 7.0 as is and got an error. It was the same error as #1 .
Following deprecation warning, I solved this problem by using `Rails.application.reloader.to_prepare` block.

Deprecation warning:

````
WARN -- : DEPRECATION WARNING: Initialization autoloaded the constants ActiveStorage::SetCurrent and ActiveStorage::BaseController.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActiveStorage::SetCurrent, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
````